### PR TITLE
Sprint 5: Endpoints para gerenciamento dos pedidos

### DIFF
--- a/ecommerce-api/src/main/java/com/example/equipecao/ecommerce_api/config/SecurityConfig.java
+++ b/ecommerce-api/src/main/java/com/example/equipecao/ecommerce_api/config/SecurityConfig.java
@@ -61,7 +61,7 @@ public class SecurityConfig {
         http
             .csrf(csrf -> csrf.disable()) // Desabilitar CSRF para testes
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/", "/login", "/signup","/backoffice-login", "/catalog", "/faq", "/cart", "/product", "/401", "/checkout","/api/produtos", "/api/produtos/**", "/api/produtos/search", "/api/produtos/distribuidor/**", "/api/usuarios", "/api/clientes","/static/vendor/**", "/static/assets/**").permitAll() // Permitir acesso público à página de login, arquivos estáticos e etc
+                .requestMatchers("/", "/login", "/signup","/backoffice-login", "/catalog", "/faq", "/cart", "/product", "/401", "/checkout","/api/produtos", "/api/pedidos", "/api/produtos/**", "/api/produtos/search", "/api/produtos/distribuidor/**", "/api/usuarios", "/api/clientes","/static/vendor/**", "/static/assets/**").permitAll() // Permitir acesso público à página de login, arquivos estáticos e etc
                 .requestMatchers("/backoffice", "/profile", "/api/auth/me").authenticated() // Requer autenticação para acessar o backoffice, profile e etc
                 .anyRequest().authenticated()
             )

--- a/ecommerce-api/src/main/java/com/example/equipecao/ecommerce_api/controller/PedidoController.java
+++ b/ecommerce-api/src/main/java/com/example/equipecao/ecommerce_api/controller/PedidoController.java
@@ -1,0 +1,75 @@
+package com.example.equipecao.ecommerce_api.controller;
+
+import com.example.equipecao.ecommerce_api.model.Pedido;
+import com.example.equipecao.ecommerce_api.model.StatusPedido;
+import com.example.equipecao.ecommerce_api.repository.PedidoRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/pedidos")
+@CrossOrigin
+public class PedidoController {
+
+    @Autowired
+    private PedidoRepository pedidoRepository;
+
+    // Criar pedido
+    @PostMapping
+    public ResponseEntity<Pedido> criarPedido(@RequestBody Pedido pedido) {
+        pedido.setStatus(StatusPedido.AGUARDANDO_PAGAMENTO);
+        Pedido novoPedido = pedidoRepository.save(pedido);
+        return ResponseEntity.status(HttpStatus.CREATED).body(novoPedido);
+    }
+
+    // Listar todos os pedidos
+    @GetMapping
+    public ResponseEntity<List<Pedido>> listarTodosOsPedidos() {
+        List<Pedido> pedidos = pedidoRepository.findAll();
+        return ResponseEntity.ok(pedidos);
+    }
+
+    // Listar pedido por ID
+    @GetMapping("/{id}")
+    public ResponseEntity<Pedido> listarPedidoPorId(@PathVariable Long id) {
+        Optional<Pedido> pedido = pedidoRepository.findById(id);
+        return pedido.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    // Listar todos os pedidos por ID do usuário
+    @GetMapping("/usuario/{usuarioId}")
+    public ResponseEntity<List<Pedido>> listarPedidosPorUsuarioId(@PathVariable Long usuarioId) {
+        List<Pedido> pedidos = pedidoRepository.findByClienteId(usuarioId);
+        return ResponseEntity.ok(pedidos);
+    }
+
+    // Atualizar status do pedido por ID
+    @PatchMapping("/{id}/status")
+    public ResponseEntity<Pedido> atualizarStatusPedido(@PathVariable Long id, @RequestParam StatusPedido status) {
+        Optional<Pedido> pedidoOptional = pedidoRepository.findById(id);
+        if (pedidoOptional.isPresent()) {
+            Pedido pedido = pedidoOptional.get();
+            pedido.setStatus(status);
+            pedidoRepository.save(pedido);
+            return ResponseEntity.ok(pedido);
+        } else {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    // Excluir pedido
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> excluirPedido(@PathVariable Long id) {
+        if (pedidoRepository.existsById(id)) {
+            pedidoRepository.deleteById(id);
+            return ResponseEntity.noContent().build();
+        } else {
+            return ResponseEntity.notFound().build();
+        }
+    }
+}

--- a/ecommerce-api/src/main/java/com/example/equipecao/ecommerce_api/model/FormaPagamento.java
+++ b/ecommerce-api/src/main/java/com/example/equipecao/ecommerce_api/model/FormaPagamento.java
@@ -1,0 +1,7 @@
+package com.example.equipecao.ecommerce_api.model;
+
+public enum FormaPagamento {
+    CARTAO_CREDITO,
+    PIX,
+    BOLETO
+}

--- a/ecommerce-api/src/main/java/com/example/equipecao/ecommerce_api/model/ItemPedido.java
+++ b/ecommerce-api/src/main/java/com/example/equipecao/ecommerce_api/model/ItemPedido.java
@@ -1,0 +1,34 @@
+package com.example.equipecao.ecommerce_api.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "TB_ItemPedido")
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ItemPedido {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @NotNull
+    private long produtoId;
+
+    @NotNull
+    private String nomeProduto;
+
+    @NotNull
+    private BigDecimal valorUnitario;
+
+    @NotNull
+    private int quantidade;
+}

--- a/ecommerce-api/src/main/java/com/example/equipecao/ecommerce_api/model/Pedido.java
+++ b/ecommerce-api/src/main/java/com/example/equipecao/ecommerce_api/model/Pedido.java
@@ -1,0 +1,49 @@
+package com.example.equipecao.ecommerce_api.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Table(name = "TB_Pedido")
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Pedido {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @NotNull
+    private LocalDateTime dataPedido;
+
+    @NotNull
+    private BigDecimal valorTotal;
+
+    @Enumerated(EnumType.STRING)
+    private StatusPedido status;
+
+    @Enumerated(EnumType.STRING)
+    private FormaPagamento formaPagamento;
+
+    @NotNull
+    private long clienteId;
+
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "pedido_id")
+    private List<ItemPedido> itens;
+
+    @PrePersist
+    public void prePersist() {
+        this.dataPedido = LocalDateTime.now();
+        this.status = StatusPedido.AGUARDANDO_PAGAMENTO;
+    }
+}

--- a/ecommerce-api/src/main/java/com/example/equipecao/ecommerce_api/model/StatusPedido.java
+++ b/ecommerce-api/src/main/java/com/example/equipecao/ecommerce_api/model/StatusPedido.java
@@ -1,0 +1,9 @@
+package com.example.equipecao.ecommerce_api.model;
+
+public enum StatusPedido {
+    AGUARDANDO_PAGAMENTO,
+    PAGO,
+    ENVIADO,
+    ENTREGUE,
+    CANCELADO
+}

--- a/ecommerce-api/src/main/java/com/example/equipecao/ecommerce_api/repository/PedidoRepository.java
+++ b/ecommerce-api/src/main/java/com/example/equipecao/ecommerce_api/repository/PedidoRepository.java
@@ -1,0 +1,10 @@
+package com.example.equipecao.ecommerce_api.repository;
+
+import com.example.equipecao.ecommerce_api.model.Pedido;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PedidoRepository extends JpaRepository<Pedido, Long> {
+    List<Pedido> findByClienteId(Long clienteId);
+}


### PR DESCRIPTION
Foram adicionados os seguintes endpoints para gerenciar os pedidos do ecommerce:

**POST** /api/pedidos: Criar um novo pedido.
**GET** /api/pedidos: Listar todos os pedidos.
**GET** /api/pedidos/{id}: Listar pedido por ID.
**GET** /api/pedidos/usuario/{usuarioId}: Listar todos os pedidos por ID do usuário.
**PATCH** /api/pedidos/{id}/status: Atualizar status do pedido por ID.
**DELETE** /api/pedidos/{id}: Excluir pedido.

Todos os endpoints com exemplos estão adicionados na documentação da API que pode ser acessada no link abaixo:
https://documenter.getpostman.com/view/17818747/2sAXqs82po#872f6016-8a71-4532-87bf-2a8bf6e19b03